### PR TITLE
replaced unicode characters with MaterialUI icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1544,6 +1544,14 @@
         }
       }
     },
+    "@material-ui/icons": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.9.1.tgz",
+      "integrity": "sha512-GBitL3oBWO0hzBhvA9KxqcowRUsA0qzwKkURyC8nppnC3fw54KPKZ+d4V1Eeg/UnDRSzDaI9nGCdel/eh9AQMg==",
+      "requires": {
+        "@babel/runtime": "^7.4.4"
+      }
+    },
     "@material-ui/styles": {
       "version": "4.10.0",
       "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.10.0.tgz",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@emotion/core": "^10.0.35",
     "@material-ui/core": "^4.11.0",
+    "@material-ui/icons": "^4.9.1",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.0.4",
     "@testing-library/user-event": "^12.1.5",

--- a/src/pages/ClubPage.css
+++ b/src/pages/ClubPage.css
@@ -93,6 +93,9 @@
 }
 
 .tag {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
   margin-left: 0.5vw;
   background-color: #e2e2e2;
   border-radius: 6px;
@@ -100,6 +103,10 @@
   font-family: Qanelas Soft;
   font-size: 1.1vw;
   flex-direction: row;
+}
+
+.tag span {
+  margin-left: 0.3em;
 }
 
 .app-flex {

--- a/src/pages/ClubPage.js
+++ b/src/pages/ClubPage.js
@@ -7,6 +7,10 @@ import { withRouter } from 'react-router-dom';
 import { getOrganization, clearOrganization } from '../actions/catalog';
 import { connect } from 'react-redux';
 import ReactGA from 'react-ga';
+import CreateIcon from '@material-ui/icons/CreateRounded';
+import HappyIcon from '@material-ui/icons/SentimentSatisfiedRounded';
+import CheckIcon from '@material-ui/icons/CheckRounded';
+import CrossIcon from '@material-ui/icons/CloseRounded';
 
 function ClubPage({
   organization,
@@ -69,21 +73,25 @@ function ClubPage({
 
   const appReq = organization.app_required ? (
     <div className="tag" id="app-req">
-      ✎ Requires App
+      <CreateIcon style={{ fontSize: '1em'}} />
+      <span>Requires App</span>
     </div>
   ) : (
     <div className="tag" id="app-not-req">
-      ☺︎ No App Required
+      <HappyIcon style={{ fontSize: '1em'}} />
+      <span>No App Required</span>
     </div>
   );
 
   const clubOpen = organization.new_members ? (
     <div className="tag" id="open-tag">
-      ✓ Taking New Members
+      <CheckIcon style={{ fontSize: '1em'}} />
+      <span>Taking New Members</span>
     </div>
   ) : (
     <div className="tag" id="not-open-tag">
-      ✗ Not Taking New Members
+      <CrossIcon style={{ fontSize: '1em'}} />
+      <span>Not Taking New Members</span>
     </div>
   );
 

--- a/src/pages/GridComponent.css
+++ b/src/pages/GridComponent.css
@@ -37,6 +37,9 @@
 }
 
 .grid-tag {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
   margin-top: 8px;
   margin-left: 15px;
   background-color: #E2E2E2;
@@ -44,6 +47,10 @@
   padding: 0vw 0.5vw 0vw 0.5vw;
   font-family: Qanelas Soft Semi Bold;
   font-size: 17px;
+}
+
+.grid-tag span {
+  margin-left: 0.3em;
 }
 
 .req-flex {

--- a/src/pages/GridComponent.js
+++ b/src/pages/GridComponent.js
@@ -16,6 +16,10 @@ import { withRouter, Link } from 'react-router-dom';
 import { searchClubs } from '../actions/catalog';
 import './GridComponent.css';
 import { makeStyles } from '@material-ui/core/styles';
+import CreateIcon from '@material-ui/icons/CreateRounded';
+import HappyIcon from '@material-ui/icons/SentimentSatisfiedRounded';
+import CheckIcon from '@material-ui/icons/CheckRounded';
+import CrossIcon from '@material-ui/icons/CloseRounded';
 
 function GridComponent({ tagOptions, clubs, num_clubs, loading }) {
   const useStyles = makeStyles({
@@ -66,32 +70,24 @@ function GridComponent({ tagOptions, clubs, num_clubs, loading }) {
               <div className="req-flex">
                 {club.app_required ? (
                   <div className="grid-tag" id="app-req">
-                    <span role="img" aria-label="emoji">
-                      ✎
-                    </span>{' '}
-                    Requires App
+                    <CreateIcon style={{ fontSize: '1em'}} />
+                    <span>Requires App</span>
                   </div>
                 ) : (
                   <div className="grid-tag" id="app-not-req">
-                    <span role="img" aria-label="emoji">
-                      ☺︎
-                    </span>{' '}
-                    No App Required
+                    <HappyIcon style={{ fontSize: '1em'}} />
+                    <span>No App Required</span>
                   </div>
                 )}
                 {club.new_members ? (
                   <div className="grid-tag" id="open-tag">
-                    <span role="img" aria-label="emoji">
-                      ✓
-                    </span>{' '}
-                    Taking New Members
+                    <CheckIcon style={{ fontSize: '1em'}} />
+                    <span>Taking New Members</span>
                   </div>
                 ) : (
                   <div className="grid-tag" id="not-open-tag">
-                    <span role="img" aria-label="emoji">
-                      ✗
-                    </span>{' '}
-                    Not Taking New Members
+                    <CrossIcon style={{ fontSize: '1em'}} />
+                    <span>Not Taking New Members</span>
                   </div>
                 )}
               </div>


### PR DESCRIPTION
Matt had claimed that the application was already using FontAwesome, but I didn't find its node modules (Only a small JS function was imported). We are already using @material-ui/core so I imported @material-ui/icons and used those icons to replace existing Unicode. This will allow for consistent icon display across all platforms.