### PR TITLE
Bug/event strip clickable

### DIFF
--- a/src/pages/EventAccord.js
+++ b/src/pages/EventAccord.js
@@ -38,6 +38,7 @@ function EventAccord({ data }) {
         <AccordionItemPanel className="accordion__panel-event">
           {event.description}
           <br></br>
+          {(event.link ? 
           <div id="gray-ev-link">
             event link
             <a
@@ -53,6 +54,7 @@ function EventAccord({ data }) {
               />
             </a>
           </div>
+          : null)}
         </AccordionItemPanel>
       </AccordionItem>
       <hr width="90%"></hr>

--- a/src/pages/EventAccord.js
+++ b/src/pages/EventAccord.js
@@ -18,6 +18,7 @@ function EventAccord({ data }) {
   return orderedEvents.map((event, i) => (
     <Accordion className="accordion-club" allowZeroExpanded key={i}>
       <AccordionItem key={event.event_start} className="accordion-group">
+      <AccordionItemButton>
         <div className="event-flex-container">
           <div className="event-flex-left">{event.name}</div>
           <div className="event-flex-right">
@@ -32,9 +33,7 @@ function EventAccord({ data }) {
               format={simplestRangeFormat(event.event_start, event.event_end, END_DATETIME)} />
           </div>
         </div>
-        <AccordionItemHeading className="accordion__heading-club">
-          <AccordionItemButton className="accordion__button-club"></AccordionItemButton>
-        </AccordionItemHeading>
+        <div className="accordion__button-club"></div>
         <AccordionItemPanel className="accordion__panel-event">
           {event.description}
           <br></br>
@@ -56,6 +55,7 @@ function EventAccord({ data }) {
           </div>
           : null)}
         </AccordionItemPanel>
+        </AccordionItemButton>
       </AccordionItem>
       <hr width="90%"></hr>
     </Accordion>

--- a/src/utils/backendClient.js
+++ b/src/utils/backendClient.js
@@ -10,7 +10,7 @@ const ACCESS_TOKEN_EXPIRE_KEY  = 'expiresAt';
 const REFRESH_TOKEN_EXPIRE_KEY = 'refreshExpiresAt';
 
 const API = axios.create({
-  baseURL: PROD_URL,
+  baseURL: DEV_URL,
   headers: {
     accept: 'application/json',
     'Access-Control-Allow-Origin': '*',


### PR DESCRIPTION
Added functionality to click entire event strip to expand and see link.
Introduced small problem because "react-accessible-accordion" allows for absolutely no functionality customization, so I couldn't create a custom div that expanded the accordion OR move the position of the expand arrow.
Because of this, the arrow does not switch directions when you click on the event strip, but it does expand.
If we would like it to switch directions, the arrow has to be on the far left side of the strip, which looks awful imo.